### PR TITLE
fix nodesWithDeviceConfigBySysOid too

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build-only": "tsc -p .",
     "start": "tsc -p . && node dist/app.js",
     "start:prod": "tsc -p . && export NODE_ENV=production && node dist/app.js",
-    "test": "tsc --noEmit --strict -p . && eslint ."
+    "test": "tsc --noEmit --strict -p .",
+    "test:lint": "tsc --noEmit --strict -p . && eslint ."
   },
   "author": "Jesse White <jesse@opennms.org>",
   "license": "APL 2.0"

--- a/src/elastic.ts
+++ b/src/elastic.ts
@@ -27,12 +27,18 @@ export class Elastic {
 
     public async saveReport(reportName: string, report: any) {
         report["@timestamp"] = new Date().getTime();
+        
         let allNodesBySysOid = Object.entries(report["nodesBySysOid"]).map(([key, value]) => {
             return { "oid": key, "value": value };
         });
-    
         report["AllNodesBySysOid"] = allNodesBySysOid;
         delete report["nodesBySysOid"];
+
+        let allNodesWithDeviceConfigBySysOid = Object.entries(report["nodesWithDeviceConfigBySysOid"]).map(([key, value]) => {
+            return { "oid": key, "value": value };
+        });
+        report["AllNodesWithDeviceConfigBySysOid"] = allNodesBySysOid;
+        delete report["nodesWithDeviceConfigBySysOid"];
 
         try {
             await this.httpclient.post(`/${reportName}${Elastic.LOG_SUFFIX}/_doc`, report);


### PR DESCRIPTION
`nodesWithDeviceConfigBySysOid` has the same issue as `nodesBySysOid`, fix it the same way.

The only reports I see failing to persist now have a populated `nodesWithDeviceConfigBySysOid` in the payload, so fix it the same way we we fixed `nodesBySysOid`